### PR TITLE
num_shards fix

### DIFF
--- a/wordvecspace/convert.py
+++ b/wordvecspace/convert.py
@@ -1,5 +1,6 @@
 import os
 import json
+import math
 from datetime import datetime
 
 import numpy as np
@@ -192,7 +193,7 @@ class GW2VectoWordVecSpaceFile(object):
         vecs = self._iter_vecs(inp_vecs, vocab_file)
         N = self.nvecs_per_shard
         if N:
-            num_shards = int(nvecs / N) + 1
+            num_shards = math.ceil(nvecs/N)
         else:
             num_shards = 1
 

--- a/wordvecspace/convert.py
+++ b/wordvecspace/convert.py
@@ -193,7 +193,7 @@ class GW2VectoWordVecSpaceFile(object):
         vecs = self._iter_vecs(inp_vecs, vocab_file)
         N = self.nvecs_per_shard
         if N:
-            num_shards = math.ceil(nvecs/N)
+            num_shards = math.ceil(nvecs / N)
         else:
             num_shards = 1
 


### PR DESCRIPTION
It works when we have 6000001 vectors and num_vec_per_shard is 2M. For example (6000001/2000000)+1 gives 4.

But the problem comes when we have 6000000 vectors. In that case also we will get 4 shards instead of 3.