### PR TITLE
num_shards fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ deploy:
   skip_cleanup: true
   api-key:
     secure: LmVvlW+FdYNIDlinjJ4sieONrcx1jaw18J7/mpHBD9ppIWZ+TB6H/iNqkqkh4WvULZttJrTHRYE6rQHXww7KK2UMrjVNE/TVUPaLFDeRRFvLDinAbqJkn+QJia0TuRa/26Bg9cDcvNYTghy7s37xpK2bJTEMF/eCM9b9RHYXilESYy8Z4l8IkFn5vnaDDfT5iV8xjuuOE4lsf4KC3L0xXIkYnKC/LbDVDj3B9h52TpsteL6cZtn/ExAThor5SrVymW7oMR1qrPQv8btNAdxymqJvEbjaP5RUuX7ehihev0Yge47A2X9gvxDRv+a6wM0HOvT4aGsMwCWo++fb0taWH7HUXFxSvkzKhsl74kDMmnE0WarcI/8L/3Q/zRhW1a2vAtj3O0FDHtzS/OK/k3TDk6Fh/LOvk2mTuGD3L34YxJrXxDxnt4tK2ubde8cGeA7pI5jRLNTNQXUip6Dxhr/5ZnMmG2nHI6ujjmDnucE+CHBtUmS1wjBn6ootE4pdoyti0aaA9OrVoGrf39pK7FAG38KJghqn8I3YCLoeapWjI4/DI0WIfq2Vl+v6yQar3Dn9lBLpWFLrjUmZnAx2F1e0P2y0VUg9hl0bINzIIrm2mHw4Zsl2GlMVSR033cwvcbdyeNxKMAfSV3EZBDpNuI6nlkkUZG1O72N/WV+kFRtSdQA=
-  name: wordvecspace-0.5.5
-  tag_name: 0.5.5
+  name: wordvecspace-0.5.6
+  tag_name: 0.5.6
   true:
     repo: deep-compute/wordvecspace
 - provider: pypi

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = "0.5.5"
+version = "0.5.6"
 setup(
     name="wordvecspace",
     python_requires=">3.5.1",

--- a/wordvecspace/convert.py
+++ b/wordvecspace/convert.py
@@ -1,5 +1,6 @@
 import os
 import json
+import math
 from datetime import datetime
 
 import numpy as np
@@ -192,7 +193,7 @@ class GW2VectoWordVecSpaceFile(object):
         vecs = self._iter_vecs(inp_vecs, vocab_file)
         N = self.nvecs_per_shard
         if N:
-            num_shards = int(nvecs / N) + 1
+            num_shards = math.ceil(nvecs / N)
         else:
             num_shards = 1
 


### PR DESCRIPTION
It works when we have 6000001 vectors and num_vec_per_shard is 2M. For example (6000001/2000000)+1 gives 4.

But the problem comes when we have 6000000 vectors. In that case also we will get 4 shards instead of 3.